### PR TITLE
Fix for MacPorts on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,21 @@ ifeq ($(PLATFORM),Darwin)
 	ifneq ($(wildcard /usr/local/Cellar/gcc/7.3.0/bin/*),)
 		CC=/usr/local/Cellar/gcc/7.3.0/bin/g++-7
 		CXX=/usr/local/Cellar/gcc/7.3.0/bin/g++-7
+	else
+		# support for Xcode/clang
+		CC=g++
+		CXX=g++
+		CFLAGS+=-std=c++14
+		CXXFLAGS+=-std=c++14
 	endif
 	OPENCL_LIBS=-framework OpenCL
 	LIBS+=-L/usr/local/opt/pcre/lib
 	CFLAGS+=-I/usr/local/opt/pcre/include
 	LIBS+=-L/usr/local/opt/openssl/lib
 	CFLAGS+=-I/usr/local/opt/openssl/include
+	# Below 2 lines add support for MacPorts
+	LIBS+=-L/opt/local/lib
+	CFLAGS+=-I/opt/local/include
 else
 	CC=g++-7
 	CXX=g++-7


### PR DESCRIPTION
This wouldn't build on my Xcode (clang) based MacPorts Mac.

This fixes the Makefile non-destructively to also build on Macs that are Xcode based and also use MacPorts as opposed to using Brew.  Tested and works.
